### PR TITLE
initialise device only for fake keyboard or xbox360 modes

### DIFF
--- a/gptokeyb.cpp
+++ b/gptokeyb.cpp
@@ -107,10 +107,12 @@ bool openbor_mode = false;
 bool xbox360_mode = false;
 char* AppToKill;
 bool config_mode = false;
+bool hotkey_override = false;
+char* hotkey_code;
 
 struct
 {
-  int back_jsdevice;
+  int hotkey_jsdevice;
   int start_jsdevice;
   int mouseX = 0;
   int mouseY = 0;
@@ -120,7 +122,7 @@ struct
   int current_right_analog_y = 0;
   int current_l2 = 0;
   int current_r2 = 0;
-  bool back_pressed = false;
+  bool hotkey_pressed = false;
   bool start_pressed = false;
   bool left_analog_was_up = false;
   bool left_analog_was_down = false;
@@ -653,10 +655,10 @@ bool handleEvent(const SDL_Event& event)
 
           case SDL_CONTROLLER_BUTTON_LEFTSTICK:
             emitKey(BTN_THUMBL, is_pressed);
-            if (kill_mode) {
-                state.back_jsdevice = event.cdevice.which;
-                state.back_pressed = is_pressed;
-            }
+            if (kill_mode && hotkey_override && (strcmp(hotkey_code, "l3") == 0)) {
+                state.hotkey_jsdevice = event.cdevice.which;
+                state.hotkey_pressed = is_pressed;
+            };
             break;
 
           case SDL_CONTROLLER_BUTTON_RIGHTSTICK:
@@ -665,18 +667,18 @@ bool handleEvent(const SDL_Event& event)
 
           case SDL_CONTROLLER_BUTTON_BACK: // aka select
             emitKey(BTN_SELECT, is_pressed);
-            if (kill_mode) {
-              state.back_jsdevice = event.cdevice.which;
-              state.back_pressed = is_pressed;
-           }
+            if ((kill_mode && !(hotkey_override)) || (kill_mode && hotkey_override && (strcmp(hotkey_code, "back") == 0))) {
+              state.hotkey_jsdevice = event.cdevice.which;
+              state.hotkey_pressed = is_pressed;
+           };
             break;
 
           case SDL_CONTROLLER_BUTTON_GUIDE:
             emitKey(BTN_MODE, is_pressed);
-            if (kill_mode) {
-              state.back_jsdevice = event.cdevice.which;
-              state.back_pressed = is_pressed;
-            }
+            if ((kill_mode && !(hotkey_override)) || (kill_mode && hotkey_override && (strcmp(hotkey_code, "guide") == 0))) {
+              state.hotkey_jsdevice = event.cdevice.which;
+              state.hotkey_pressed = is_pressed;
+            };
             break;
 
           case SDL_CONTROLLER_BUTTON_START:
@@ -703,10 +705,10 @@ bool handleEvent(const SDL_Event& event)
             emitAxisMotion(ABS_HAT0X, is_pressed ? 1 : 0);
             break;
         }
-         if ((kill_mode) && (state.start_pressed && state.back_pressed)) {
+         if ((kill_mode) && (state.start_pressed && state.hotkey_pressed)) {
           if (! sudo_kill) {
              // printf("Killing: %s\n", AppToKill);
-             if (state.start_jsdevice == state.back_jsdevice) {
+             if (state.start_jsdevice == state.hotkey_jsdevice) {
                 system((" killall  '" + std::string(AppToKill) + "' ").c_str());
                 system("show_splash.sh exit");
                sleep(3);
@@ -720,7 +722,7 @@ bool handleEvent(const SDL_Event& event)
             exit(0); 
             }             
           } else {
-             if (state.start_jsdevice == state.back_jsdevice) {
+             if (state.start_jsdevice == state.hotkey_jsdevice) {
                 system((" kill -9 $(pidof '" + std::string(AppToKill) + "') ").c_str());
                sleep(3);
                exit(0);
@@ -773,10 +775,10 @@ bool handleEvent(const SDL_Event& event)
 
           case SDL_CONTROLLER_BUTTON_LEFTSTICK:
             emitKey(config.l3, is_pressed);
-            if (kill_mode) {
-                state.back_jsdevice = event.cdevice.which;
-                state.back_pressed = is_pressed;
-            }
+            if (kill_mode && hotkey_override && (strcmp(hotkey_code, "l3") == 0)) {
+                state.hotkey_jsdevice = event.cdevice.which;
+                state.hotkey_pressed = is_pressed;
+            };
             break;
 
           case SDL_CONTROLLER_BUTTON_RIGHTSTICK:
@@ -785,18 +787,18 @@ bool handleEvent(const SDL_Event& event)
 
           case SDL_CONTROLLER_BUTTON_GUIDE:
             emitKey(config.guide, is_pressed);
-            if (kill_mode) {
-                state.back_jsdevice = event.cdevice.which;
-                state.back_pressed = is_pressed;
-            }
+            if ((kill_mode && !(hotkey_override)) || (kill_mode && hotkey_override && (strcmp(hotkey_code, "guide") == 0))) {
+              state.hotkey_jsdevice = event.cdevice.which;
+              state.hotkey_pressed = is_pressed;
+            };
             break;
 
           case SDL_CONTROLLER_BUTTON_BACK: // aka select
             emitKey(config.back, is_pressed);
-            if (kill_mode) {
-                state.back_jsdevice = event.cdevice.which;
-                state.back_pressed = is_pressed;
-            }
+            if ((kill_mode && !(hotkey_override)) || (kill_mode && hotkey_override && (strcmp(hotkey_code, "back") == 0))) {
+              state.hotkey_jsdevice = event.cdevice.which;
+              state.hotkey_pressed = is_pressed;
+            };
             break;
 
           case SDL_CONTROLLER_BUTTON_START:
@@ -804,13 +806,13 @@ bool handleEvent(const SDL_Event& event)
             if (kill_mode) {
                 state.start_jsdevice = event.cdevice.which;
                 state.start_pressed = is_pressed;
-            }
+            };
             break;
         }
-        if ((kill_mode) && (state.start_pressed && state.back_pressed)) {
+        if ((kill_mode) && (state.start_pressed && state.hotkey_pressed)) {
           if (! sudo_kill) {
              // printf("Killing: %s\n", AppToKill);
-             if (state.start_jsdevice == state.back_jsdevice) {
+             if (state.start_jsdevice == state.hotkey_jsdevice) {
                 system((" killall  '" + std::string(AppToKill) + "' ").c_str());
                 system("show_splash.sh exit");
                sleep(3);
@@ -824,7 +826,7 @@ bool handleEvent(const SDL_Event& event)
             exit(0); 
             }             
           } else {
-             if (state.start_jsdevice == state.back_jsdevice) {
+             if (state.start_jsdevice == state.hotkey_jsdevice) {
                 system((" kill -9 $(pidof '" + std::string(AppToKill) + "') ").c_str());
                sleep(3);
                exit(0);
@@ -1009,6 +1011,11 @@ int main(int argc, char* argv[])
       } else {
         config_mode = true;
         config_file = "/emuelec/configs/gptokeyb/default.gptk";
+      }
+    } else if (strcmp(argv[ii], "-hotkey") == 0) {
+      if (ii + 1 < argc) {
+        hotkey_override = true;
+        hotkey_code = argv[++ii];
       }
     } else if ((strcmp(argv[ii], "1") == 0) || (strcmp(argv[ii], "-1") == 0) || (strcmp(argv[ii], "-k") == 0)) {
       if (ii + 1 < argc) { 

--- a/gptokeyb.cpp
+++ b/gptokeyb.cpp
@@ -1033,7 +1033,8 @@ int main(int argc, char* argv[])
   }
 
   // Create fake input device (not needed in kill mode)
-  //if (!kill_mode) {  initialise device, now that kill mode will work with config & xbox modes
+  //if (!kill_mode) {  
+  if (config_mode || xbox360_mode) { // initialise device, even in kill mode, now that kill mode will work with config & xbox modes
     uinp_fd = open("/dev/uinput", O_WRONLY | O_NONBLOCK);
     if (uinp_fd < 0) {
       printf("Unable to open /dev/uinput\n");
@@ -1065,7 +1066,7 @@ int main(int argc, char* argv[])
       printf("Unable to create UINPUT device.");
       return -1;
     }
-  //}
+  }
 
   if (const char* db_file = SDL_getenv("SDL_GAMECONTROLLERCONFIG_FILE")) {
     SDL_GameControllerAddMappingsFromFile(db_file);

--- a/gptokeyb.cpp
+++ b/gptokeyb.cpp
@@ -995,6 +995,12 @@ int main(int argc, char* argv[])
   config_mode = true;
   config_file = "/emuelec/configs/gptokeyb/default.gptk";
 
+  // Add hotkey environment variable if available
+  if (char* env_hotkey = SDL_getenv("HOTKEY")) {
+    hotkey_override = true;
+    hotkey_code = env_hotkey;
+  }
+
   if (argc > 1) {
     config_mode = false;
     config_file = "";

--- a/gptokeyb.cpp
+++ b/gptokeyb.cpp
@@ -865,25 +865,33 @@ bool handleEvent(const SDL_Event& event)
             break;
         }
       } else {
+        // indicate which axis was moved before checking whether it's assigned as mouse
+        bool left_axis_movement = false;
+        bool right_axis_movement = false;
+        
         switch (event.caxis.axis) {
           case SDL_CONTROLLER_AXIS_LEFTX:
             state.current_left_analog_x =
               applyDeadzone(event.caxis.value, config.deadzone_x);
+              left_axis_movement = true;
             break;
 
           case SDL_CONTROLLER_AXIS_LEFTY:
             state.current_left_analog_y =
               applyDeadzone(event.caxis.value, config.deadzone_y);
+              left_axis_movement = true;
             break;
 
           case SDL_CONTROLLER_AXIS_RIGHTX:
             state.current_right_analog_x =
               applyDeadzone(event.caxis.value, config.deadzone_x);
+              right_axis_movement = true;
             break;
 
           case SDL_CONTROLLER_AXIS_RIGHTY:
             state.current_right_analog_y =
               applyDeadzone(event.caxis.value, config.deadzone_y);
+              right_axis_movement = true;
             break;
 
           case SDL_CONTROLLER_AXIS_TRIGGERLEFT:
@@ -896,10 +904,10 @@ bool handleEvent(const SDL_Event& event)
         }
 
         // fake mouse
-        if (config.left_analog_as_mouse) {
+        if (config.left_analog_as_mouse && left_axis_movement) {
           state.mouseX = state.current_left_analog_x / config.fake_mouse_scale;
           state.mouseY = state.current_left_analog_y / config.fake_mouse_scale;
-        } else if (config.right_analog_as_mouse) {
+        } else if (config.right_analog_as_mouse && right_axis_movement) {
           state.mouseX = state.current_right_analog_x / config.fake_mouse_scale;
           state.mouseY = state.current_right_analog_y / config.fake_mouse_scale;
         } else {

--- a/gptokeyb.cpp
+++ b/gptokeyb.cpp
@@ -107,12 +107,10 @@ bool openbor_mode = false;
 bool xbox360_mode = false;
 char* AppToKill;
 bool config_mode = false;
-bool hotkey_override = false;
-char* hotkey_code;
 
 struct
 {
-  int hotkey_jsdevice;
+  int back_jsdevice;
   int start_jsdevice;
   int mouseX = 0;
   int mouseY = 0;
@@ -122,7 +120,7 @@ struct
   int current_right_analog_y = 0;
   int current_l2 = 0;
   int current_r2 = 0;
-  bool hotkey_pressed = false;
+  bool back_pressed = false;
   bool start_pressed = false;
   bool left_analog_was_up = false;
   bool left_analog_was_down = false;
@@ -655,10 +653,10 @@ bool handleEvent(const SDL_Event& event)
 
           case SDL_CONTROLLER_BUTTON_LEFTSTICK:
             emitKey(BTN_THUMBL, is_pressed);
-            if (kill_mode && hotkey_override && (strcmp(hotkey_code, "l3") == 0)) {
-                state.hotkey_jsdevice = event.cdevice.which;
-                state.hotkey_pressed = is_pressed;
-            };
+            if (kill_mode) {
+                state.back_jsdevice = event.cdevice.which;
+                state.back_pressed = is_pressed;
+            }
             break;
 
           case SDL_CONTROLLER_BUTTON_RIGHTSTICK:
@@ -667,18 +665,18 @@ bool handleEvent(const SDL_Event& event)
 
           case SDL_CONTROLLER_BUTTON_BACK: // aka select
             emitKey(BTN_SELECT, is_pressed);
-            if ((kill_mode && !(hotkey_override)) || (kill_mode && hotkey_override && (strcmp(hotkey_code, "back") == 0))) {
-              state.hotkey_jsdevice = event.cdevice.which;
-              state.hotkey_pressed = is_pressed;
-           };
+            if (kill_mode) {
+              state.back_jsdevice = event.cdevice.which;
+              state.back_pressed = is_pressed;
+           }
             break;
 
           case SDL_CONTROLLER_BUTTON_GUIDE:
             emitKey(BTN_MODE, is_pressed);
-            if ((kill_mode && !(hotkey_override)) || (kill_mode && hotkey_override && (strcmp(hotkey_code, "guide") == 0))) {
-              state.hotkey_jsdevice = event.cdevice.which;
-              state.hotkey_pressed = is_pressed;
-            };
+            if (kill_mode) {
+              state.back_jsdevice = event.cdevice.which;
+              state.back_pressed = is_pressed;
+            }
             break;
 
           case SDL_CONTROLLER_BUTTON_START:
@@ -705,10 +703,10 @@ bool handleEvent(const SDL_Event& event)
             emitAxisMotion(ABS_HAT0X, is_pressed ? 1 : 0);
             break;
         }
-         if ((kill_mode) && (state.start_pressed && state.hotkey_pressed)) {
+         if ((kill_mode) && (state.start_pressed && state.back_pressed)) {
           if (! sudo_kill) {
              // printf("Killing: %s\n", AppToKill);
-             if (state.start_jsdevice == state.hotkey_jsdevice) {
+             if (state.start_jsdevice == state.back_jsdevice) {
                 system((" killall  '" + std::string(AppToKill) + "' ").c_str());
                 system("show_splash.sh exit");
                sleep(3);
@@ -722,7 +720,7 @@ bool handleEvent(const SDL_Event& event)
             exit(0); 
             }             
           } else {
-             if (state.start_jsdevice == state.hotkey_jsdevice) {
+             if (state.start_jsdevice == state.back_jsdevice) {
                 system((" kill -9 $(pidof '" + std::string(AppToKill) + "') ").c_str());
                sleep(3);
                exit(0);
@@ -775,10 +773,10 @@ bool handleEvent(const SDL_Event& event)
 
           case SDL_CONTROLLER_BUTTON_LEFTSTICK:
             emitKey(config.l3, is_pressed);
-            if (kill_mode && hotkey_override && (strcmp(hotkey_code, "l3") == 0)) {
-                state.hotkey_jsdevice = event.cdevice.which;
-                state.hotkey_pressed = is_pressed;
-            };
+            if (kill_mode) {
+                state.back_jsdevice = event.cdevice.which;
+                state.back_pressed = is_pressed;
+            }
             break;
 
           case SDL_CONTROLLER_BUTTON_RIGHTSTICK:
@@ -787,18 +785,18 @@ bool handleEvent(const SDL_Event& event)
 
           case SDL_CONTROLLER_BUTTON_GUIDE:
             emitKey(config.guide, is_pressed);
-            if ((kill_mode && !(hotkey_override)) || (kill_mode && hotkey_override && (strcmp(hotkey_code, "guide") == 0))) {
-              state.hotkey_jsdevice = event.cdevice.which;
-              state.hotkey_pressed = is_pressed;
-            };
+            if (kill_mode) {
+                state.back_jsdevice = event.cdevice.which;
+                state.back_pressed = is_pressed;
+            }
             break;
 
           case SDL_CONTROLLER_BUTTON_BACK: // aka select
             emitKey(config.back, is_pressed);
-            if ((kill_mode && !(hotkey_override)) || (kill_mode && hotkey_override && (strcmp(hotkey_code, "back") == 0))) {
-              state.hotkey_jsdevice = event.cdevice.which;
-              state.hotkey_pressed = is_pressed;
-            };
+            if (kill_mode) {
+                state.back_jsdevice = event.cdevice.which;
+                state.back_pressed = is_pressed;
+            }
             break;
 
           case SDL_CONTROLLER_BUTTON_START:
@@ -806,13 +804,13 @@ bool handleEvent(const SDL_Event& event)
             if (kill_mode) {
                 state.start_jsdevice = event.cdevice.which;
                 state.start_pressed = is_pressed;
-            };
+            }
             break;
         }
-        if ((kill_mode) && (state.start_pressed && state.hotkey_pressed)) {
+        if ((kill_mode) && (state.start_pressed && state.back_pressed)) {
           if (! sudo_kill) {
              // printf("Killing: %s\n", AppToKill);
-             if (state.start_jsdevice == state.hotkey_jsdevice) {
+             if (state.start_jsdevice == state.back_jsdevice) {
                 system((" killall  '" + std::string(AppToKill) + "' ").c_str());
                 system("show_splash.sh exit");
                sleep(3);
@@ -826,7 +824,7 @@ bool handleEvent(const SDL_Event& event)
             exit(0); 
             }             
           } else {
-             if (state.start_jsdevice == state.hotkey_jsdevice) {
+             if (state.start_jsdevice == state.back_jsdevice) {
                 system((" kill -9 $(pidof '" + std::string(AppToKill) + "') ").c_str());
                sleep(3);
                exit(0);
@@ -1011,11 +1009,6 @@ int main(int argc, char* argv[])
       } else {
         config_mode = true;
         config_file = "/emuelec/configs/gptokeyb/default.gptk";
-      }
-    } else if (strcmp(argv[ii], "-hotkey") == 0) {
-      if (ii + 1 < argc) {
-        hotkey_override = true;
-        hotkey_code = argv[++ii];
       }
     } else if ((strcmp(argv[ii], "1") == 0) || (strcmp(argv[ii], "-1") == 0) || (strcmp(argv[ii], "-k") == 0)) {
       if (ii + 1 < argc) { 

--- a/gptokeyb.cpp
+++ b/gptokeyb.cpp
@@ -653,6 +653,10 @@ bool handleEvent(const SDL_Event& event)
 
           case SDL_CONTROLLER_BUTTON_LEFTSTICK:
             emitKey(BTN_THUMBL, is_pressed);
+            if (kill_mode) {
+                state.back_jsdevice = event.cdevice.which;
+                state.back_pressed = is_pressed;
+            }
             break;
 
           case SDL_CONTROLLER_BUTTON_RIGHTSTICK:
@@ -769,6 +773,10 @@ bool handleEvent(const SDL_Event& event)
 
           case SDL_CONTROLLER_BUTTON_LEFTSTICK:
             emitKey(config.l3, is_pressed);
+            if (kill_mode) {
+                state.back_jsdevice = event.cdevice.which;
+                state.back_pressed = is_pressed;
+            }
             break;
 
           case SDL_CONTROLLER_BUTTON_RIGHTSTICK:
@@ -994,7 +1002,7 @@ int main(int argc, char* argv[])
         config_mode = true;
         config_file = "/emuelec/configs/gptokeyb/default.gptk";
       }
-    } else if ((strcmp(argv[ii], "-1") == 0) || (strcmp(argv[ii], "-k") == 0)) {
+    } else if ((strcmp(argv[ii], "1") == 0) || (strcmp(argv[ii], "-1") == 0) || (strcmp(argv[ii], "-k") == 0)) {
       if (ii + 1 < argc) { 
         kill_mode = true;
         AppToKill = argv[++ii];


### PR DESCRIPTION
Restore check for config mode or xbox360 mode before initialising controller device
Support obtaining hotkey from export HOTKEY environment variable when available