### PR TITLE
Fix xbox360 emulation mode.

### DIFF
--- a/gptokeyb.cpp
+++ b/gptokeyb.cpp
@@ -597,26 +597,26 @@ void setupFakeXbox360Device(uinput_user_dev& device, int fd)
     ioctl(fd, UI_SET_KEYBIT, BTN_SELECT) ||
     ioctl(fd, UI_SET_KEYBIT, BTN_START) || ioctl(fd, UI_SET_KEYBIT, BTN_MODE) ||
     // absolute (sticks)
-    ioctl(fd, UI_SET_ABSBIT, SDL_CONTROLLER_AXIS_LEFTX) ||
-    ioctl(fd, UI_SET_ABSBIT, SDL_CONTROLLER_AXIS_LEFTY) ||
-    ioctl(fd, UI_SET_ABSBIT, SDL_CONTROLLER_AXIS_RIGHTX) ||
-    ioctl(fd, UI_SET_ABSBIT, SDL_CONTROLLER_AXIS_RIGHTY) ||
-    ioctl(fd, UI_SET_ABSBIT, SDL_CONTROLLER_AXIS_TRIGGERLEFT) ||
-    ioctl(fd, UI_SET_ABSBIT, SDL_CONTROLLER_AXIS_TRIGGERRIGHT) ||
+    ioctl(fd, UI_SET_ABSBIT, ABS_X) ||
+    ioctl(fd, UI_SET_ABSBIT, ABS_Y) ||
+    ioctl(fd, UI_SET_ABSBIT, ABS_RX) ||
+    ioctl(fd, UI_SET_ABSBIT, ABS_RY) ||
+    ioctl(fd, UI_SET_ABSBIT, ABS_Z) ||
+    ioctl(fd, UI_SET_ABSBIT, ABS_RZ) ||
     ioctl(fd, UI_SET_ABSBIT, ABS_HAT0X) ||
     ioctl(fd, UI_SET_ABSBIT, ABS_HAT0Y)) {
     printf("Failed to configure fake Xbox 360 controller\n");
     exit(-1);
   }
 
-  UINPUT_SET_ABS_P(&device, SDL_CONTROLLER_AXIS_LEFTX, -32768, 32767, 16, 128);
-  UINPUT_SET_ABS_P(&device, SDL_CONTROLLER_AXIS_LEFTY, -32768, 32767, 16, 128);
-  UINPUT_SET_ABS_P(&device, SDL_CONTROLLER_AXIS_RIGHTX, -32768, 32767, 16, 128);
-  UINPUT_SET_ABS_P(&device, SDL_CONTROLLER_AXIS_RIGHTY, -32768, 32767, 16, 128);
+  UINPUT_SET_ABS_P(&device, ABS_X, -32768, 32767, 16, 128);
+  UINPUT_SET_ABS_P(&device, ABS_Y, -32768, 32767, 16, 128);
+  UINPUT_SET_ABS_P(&device, ABS_RX, -32768, 32767, 16, 128);
+  UINPUT_SET_ABS_P(&device, ABS_RY, -32768, 32767, 16, 128);
   UINPUT_SET_ABS_P(&device, ABS_HAT0X, -1, 1, 0, 0);
   UINPUT_SET_ABS_P(&device, ABS_HAT0Y, -1, 1, 0, 0);
-  UINPUT_SET_ABS_P(&device, SDL_CONTROLLER_AXIS_TRIGGERLEFT, 0, 255, 0, 0);
-  UINPUT_SET_ABS_P(&device, SDL_CONTROLLER_AXIS_TRIGGERRIGHT, 0, 255, 0, 0);
+  UINPUT_SET_ABS_P(&device, ABS_Z, 0, 255, 0, 0);
+  UINPUT_SET_ABS_P(&device, ABS_RZ, 0, 255, 0, 0);
 }
 
 bool handleEvent(const SDL_Event& event)


### PR DESCRIPTION
Previously, SDL absolute event codes were being passed to uinput, while they do not correspond to their uinput counterparts:
This PR fixes issues in games like `Don't Starve` suddenly having ghost inputs on one axis, or otherwise unresponsive trigger buttons.

```c
#define ABS_X			0x00
#define ABS_Y			0x01
#define ABS_Z			0x02
#define ABS_RX			0x03
#define ABS_RY			0x04
#define ABS_RZ			0x05
```

```c
typedef enum
{
    SDL_CONTROLLER_AXIS_INVALID = -1,
    SDL_CONTROLLER_AXIS_LEFTX, // -> ABS_X
    SDL_CONTROLLER_AXIS_LEFTY, // -> ABS_Y
    SDL_CONTROLLER_AXIS_RIGHTX, // -> ABS_RX
    SDL_CONTROLLER_AXIS_RIGHTY, // -> ABS_RY
    SDL_CONTROLLER_AXIS_TRIGGERLEFT, // -> ABS_Z
    SDL_CONTROLLER_AXIS_TRIGGERRIGHT, // -> ABS_RZ 
    SDL_CONTROLLER_AXIS_MAX
} SDL_GameControllerAxis;
```