### PR TITLE
[EE]feature -  customkill argument

### DIFF
--- a/gptokeyb.cpp
+++ b/gptokeyb.cpp
@@ -126,6 +126,7 @@ bool character_set_shift[maxKeysWithSymbols]; // indicate which keys require shi
 int current_character = 0; 
 int current_key[maxChars]; // current key selected for each key
 char* AppToKill;
+std::string customKill;
 bool config_mode = false;
 bool hotkey_override = false;
 char* hotkey_code;
@@ -1513,7 +1514,14 @@ SDL_GameController* controller = SDL_GameControllerFromInstanceID(event.cdevice.
              }
           } else {
              if (state.start_jsdevice == state.hotkey_jsdevice) {
-               system((" kill -9 $(pidof '" + std::string(AppToKill) + "') ").c_str());
+               if (customKill.length() > 0) {
+                 printf("customKill: %s\n", customKill.c_str());
+                 system((customKill + "\n").c_str());
+               }
+               else {
+                 printf("kill -9: %s\n", AppToKill);
+                 system((" kill -9 $(pidof '" + std::string(AppToKill) + "') ").c_str());
+               }
                sleep(3);
                exit(0);
              }
@@ -1842,14 +1850,21 @@ SDL_GameController* controller = SDL_GameControllerFromInstanceID(event.cdevice.
                 }
                 exit(0);
              }
-          } else {
-             if (state.start_jsdevice == state.hotkey_jsdevice) {
-               system((" kill -9 $(pidof '" + std::string(AppToKill) + "') ").c_str());
-               sleep(3);
-               exit(0);
-             }
-           } // sudo kill
-        } //kill mode 
+        } else {
+            if (state.start_jsdevice == state.hotkey_jsdevice) {
+              if (customKill.length() > 0) {
+                printf("customKill: %s\n", customKill.c_str());
+                system((customKill + "\n").c_str());
+              }
+              else {
+                printf("kill -9: %s\n", AppToKill);
+                system((" kill -9 $(pidof '" + std::string(AppToKill) + "') ").c_str());
+              }
+              sleep(3);
+              exit(0);
+            }
+          } // sudo kill
+        } //kill mode
         else if ((textinputpreset_mode) && (state.textinputpresettrigger_pressed && state.start_pressed)) { //activate input preset mode - send predefined text as a series of keystrokes
             printf("text input preset pressed\n");
             state.start_combo_triggered = true;
@@ -2205,7 +2220,22 @@ int main(int argc, char* argv[])
         if (strcmp(AppToKill, "exult") == 0) { // special adjustment for Exult, which adds double spaces during text input
           app_exult_adjust = true;
         }
-      } 
+      }
+    } else if ((strcmp(argv[ii], "-customkill") == 0)) {
+      if (ii + 1 < argc) {
+        kill_mode = true;
+        sudo_kill = true;
+        std::string nextArg(argv[ii+1]);
+        if (nextArg.length() > 1 && nextArg.front() == '"' && nextArg.back() == '"') {
+          customKill = nextArg.substr(1, nextArg.length() - 2);
+        } else {
+          if (nextArg.length() > 0) {
+              customKill = nextArg;
+          }
+        }
+        std::cout << "Found direct custom kill value: " << customKill << std::endl;
+        ii++;
+      }
     } else if (strcmp(argv[ii], "-killsignal") == 0) {
         if (ii + 1 < argc) { 
           kill_mode = true;

--- a/gptokeyb.cpp
+++ b/gptokeyb.cpp
@@ -1515,11 +1515,11 @@ SDL_GameController* controller = SDL_GameControllerFromInstanceID(event.cdevice.
           } else {
              if (state.start_jsdevice == state.hotkey_jsdevice) {
                if (customKill.length() > 0) {
-                 printf("customKill: %s\n", customKill.c_str());
+                 //printf("customKill: %s\n", customKill.c_str());
                  system((customKill + "\n").c_str());
                }
                else {
-                 printf("kill -9: %s\n", AppToKill);
+                 //printf("kill -9: %s\n", AppToKill);
                  system((" kill -9 $(pidof '" + std::string(AppToKill) + "') ").c_str());
                }
                sleep(3);
@@ -1853,11 +1853,11 @@ SDL_GameController* controller = SDL_GameControllerFromInstanceID(event.cdevice.
         } else {
             if (state.start_jsdevice == state.hotkey_jsdevice) {
               if (customKill.length() > 0) {
-                printf("customKill: %s\n", customKill.c_str());
+                //printf("customKill: %s\n", customKill.c_str());
                 system((customKill + "\n").c_str());
               }
               else {
-                printf("kill -9: %s\n", AppToKill);
+                //printf("kill -9: %s\n", AppToKill);
                 system((" kill -9 $(pidof '" + std::string(AppToKill) + "') ").c_str());
               }
               sleep(3);
@@ -2233,7 +2233,7 @@ int main(int argc, char* argv[])
               customKill = nextArg;
           }
         }
-        std::cout << "Found direct custom kill value: " << customKill << std::endl;
+        //std::cout << "Found direct custom kill value: " << customKill.c_str() << std::endl;
         ii++;
       }
     } else if (strcmp(argv[ii], "-killsignal") == 0) {


### PR DESCRIPTION
Allows a user to enter the custom kill command directly into gptokeyb. syntax is as follows:
```
// for a single command it's
gptokeyb -customkill example

// for commands with spaces it's
gptokeyb -customkill "this is an example"
```
And they will be executed directly into the system upon hotkey+start.

